### PR TITLE
LLVM package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,7 @@ RUN sudo apt-get install -y \
   flex \
   python-pystache \
   python-requests \
-  python-tz
+  python-tz \
+  llvm
 
 RUN sudo pip install cpplint


### PR DESCRIPTION
Adds the `llvm` package. I don't think `clang-tidy` and `clang-format` have landed in Debian stable yet.